### PR TITLE
ci: add annotations, improve workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Create and publish a Docker image
+name: Build Image
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: ${{ github.ref == format('refs/heads/{0}', 'main') }}
-          tags: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository_owner }}/goatcounter
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,10 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['main']
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/goatcounter
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -29,22 +28,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Get Goatcounter version
         id: tags
         run: echo "GOATCOUNTER_VERSION=$(cat Dockerfile | grep -oP '(?<=ARG GOATCOUNTER_VERSION=)(.*)')" >> $GITHUB_ENV
 
+      - name: Gather metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}},value=${{ env.GOATCOUNTER_VERSION }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.GOATCOUNTER_VERSION }}
+          push: ${{ github.ref == format('refs/heads/{0}', 'main') }}
+          tags: ${{ steps.meta.outputs.labels }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
* Build on all pushes (i.e. no branch restriction), but only push image if triggered from main branch.
* Better utilise metadata-action
* Add annotations to image